### PR TITLE
added juice inline Css function

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -23,6 +23,9 @@ function translateContent(content) {
   // Parse
   try {
     src = translation.sourcePrep(content);
+    // Copy style declaration inline
+    //
+    src = translation.inlineStyle(src);
     ast = handlebars.parse(src);
   } catch (parseError) {
     throw {

--- a/lib/translation.js
+++ b/lib/translation.js
@@ -2,7 +2,9 @@
 
 var handlebars = require('handlebars')
   , Visitor = handlebars.Visitor
-  , dbgSpew = true;
+  , dbgSpew = true
+  , juice = require('juice')
+  ;
 
 /*
  * This Handlebars AST visitor generates SparkPost template syntax.
@@ -188,10 +190,27 @@ function sourcePrep(src) {
     .replace(/\*\|([a-zA-Z0-9]*)\|\*/g, '{{$1}}');
 }
 
+// inline the style
+//
+function inlineStyle(src) {
+
+  var options
+  ;
+
+  options = {
+   removeStyleTags: false
+  };
+
+  src = juice(src, options);
+
+  return src;
+}
+
 // ----------------------------------------------------------------------------
 
 module.exports = {
   TranslationPass: TranslationPass,
-  sourcePrep: sourcePrep
+  sourcePrep: sourcePrep,
+  inlineStyle: inlineStyle
 };
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "email-addresses": "^2.0.2",
     "express": "^4.13.4",
     "handlebars": "file:vendor/handlebars",
+    "juice": "^1.10.0",
     "mandrill-api": "^1.0.45",
     "morgan": "^1.7.0",
     "q": "^1.4.1",


### PR DESCRIPTION
Hi,

I noticed that Mandrill automatically inlines all the styles on mandrill send.
When I imported the templates from mandrill to sparkpost, the CSS would be in defined in the <STYLE> tags and not inline.
So I added an inline css package to do this before the template is imported.
Now when I send with Sparkpost, my email looks exactly the same as when I send it from Mandrill due to the inline css.

Cheers